### PR TITLE
Checking for dirty values.

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -4,6 +4,7 @@ class Scope {
   constructor() {
     this.$$watchers = [];
   }
+
   $watch(watchFn, listenerFn) {
     let watcher = {
       watchFn,
@@ -11,9 +12,16 @@ class Scope {
     };
     this.$$watchers.push(watcher);
   }
+
   $digest() {
+    let newValue, oldValue;
     _.forEach(this.$$watchers, watcher => {
-      watcher.listenerFn();
+      newValue = watcher.watchFn(this);
+      oldValue = watcher.last;
+      if (newValue !== oldValue) {
+        watcher.last = newValue;
+        watcher.listenerFn(newValue, oldValue, this);
+      }
     });
   }
 }

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -21,5 +21,31 @@ describe("Scope", () => {
       scope.$digest();
       expect(listenerFn).toHaveBeenCalled();
     });
+
+    it("calls the watch function with the scope as the argument", () => {
+      let watchFn = jest.fn();
+      let listenerFn = () => null;
+      scope.$watch(watchFn, listenerFn);
+      scope.$digest();
+      expect(watchFn).toHaveBeenCalledWith(scope);
+    });
+
+    it("calls the listener function when the watch value changes", () => {
+      scope.someValue = "a";
+      scope.counter = 0;
+      scope.$watch(
+        scope => scope.someValue,
+        (newValue, oldValue, scope) => scope.counter++
+      );
+      expect(scope.counter).toBe(0);
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+      scope.someValue = "b";
+      expect(scope.counter).toBe(1);
+      scope.$digest();
+      expect(scope.counter).toBe(2);
+    });
   });
 });


### PR DESCRIPTION
Making sure that watch functions are called with the current scope. Because I'm using a fat arrow function in the $digest function, `this` is already bound and a `let self = this;` variable is not necessary.

Pass newValue, oldValue, and scope to the listener function so that end users can make decisions about when and what to do when watch value changes.